### PR TITLE
Reworking the loot tables of structure chests

### DIFF
--- a/src/main/resources/data/infernalexp/loot_tables/chests/basalt_delta_ruin_chest.json
+++ b/src/main/resources/data/infernalexp/loot_tables/chests/basalt_delta_ruin_chest.json
@@ -10,90 +10,38 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "weight": 4,
+          "weight": 7,
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
-                "min": 1.0,
-                "max": 12.0,
+                "min": 4.0,
+                "max": 22.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "infernalexp:silt"
+          "name": "minecraft:iron_ingot"
         },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "minecraft:basalt"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:basalt_wall"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:basalt_stairs"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:basalt_slab"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:polished_basalt_pressure_plate"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "name": "infernalexp:polished_basalt_tiles_slab"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "name": "infernalexp:basalt_bricks"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "name": "infernalexp:cracked_basalt_bricks"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "name": "infernalexp:chiseled_basalt_bricks"
-        },
-
         {
           "type": "minecraft:item",
           "weight": 4,
-          "name": "infernalexp:basalt_iron_ore"
+"functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 3.0,
+                "max": 10.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:gold_ingot"
         },
         {
           "type": "minecraft:item",
           "weight": 3,
-          "name": "infernalexp:basaltic_magma"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "name": "infernalexp:magmatic_chiseled_basalt_bricks"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "name": "minecraft:bowl"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "functions": [
+"functions": [
             {
               "function": "minecraft:set_count",
               "count": {
@@ -103,216 +51,43 @@
               }
             }
           ],
-          "name": "infernalexp:glowcoal"
+          "name": "infernalexp:molten_gold_cluster"
         },
         {
           "type": "minecraft:item",
-          "weight": 3,
-          "functions": [
+          "weight": 7,
+"functions": [
             {
               "function": "minecraft:set_count",
               "count": {
-                "min": 1.0,
-                "max": 4.0,
+                "min": 2.0,
+                "max": 5.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "minecraft:porkchop"
+          "name": "minecraft:chain"
         },
         {
           "type": "minecraft:item",
-          "weight": 4,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "minecraft:warped_fungus"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 3.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:luminous_fungus"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 2.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:luminous_fungus_cap"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 3.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
+          "weight": 7,
           "name": "infernalexp:strider_bucket"
         },
+
         {
           "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
+          "weight": 4,
+"functions": [
             {
               "function": "minecraft:set_count",
               "count": {
                 "min": 1.0,
-                "max": 2.0,
+                "max": 6.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "infernalexp:blindsight_tongue"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 1.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue_stew"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.3,
-                "max": 0.6
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue_whip"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.3,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:golden_axe"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "name": "minecraft:damaged_anvil"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "name": "infernalexp:shroomlight_fungus"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "name": "infernalexp:ascus_bomb"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 5.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:glownuggets"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:dullthorns"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "name": "infernalexp:music_disc_soul_spunk"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 3.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:moth_dust"
+          "name": "minecraft:bone"
         }
       ]
     }

--- a/src/main/resources/data/infernalexp/loot_tables/chests/desolate_bastion_outpost_chest.json
+++ b/src/main/resources/data/infernalexp/loot_tables/chests/desolate_bastion_outpost_chest.json
@@ -11,190 +11,79 @@
         {
           "type": "minecraft:item",
           "weight": 7,
-          "name": "infernalexp:dimstone"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:dullstone"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:glowstone_bricks"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:smooth_dimstone"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:chiseled_dullstone_bricks"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "name": "infernalexp:glowdust_sand"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "name": "infernalexp:glowdust_stone"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "name": "infernalexp:glowdust"
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 16.0,
+                "max": 22.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:iron_nugget"
         },
         {
           "type": "minecraft:item",
           "weight": 5,
-          "name": "infernalexp:glowdust_stone_brick_slab"
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 4.0,
+                "max": 13.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "infernalexp:basalt_iron"
         },
         {
           "type": "minecraft:item",
-          "weight": 4,
-          "name": "infernalexp:smooth_glowstone_stairs"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "name": "infernalexp:dimstone_brick_slab"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "name": "infernalexp:dullstone_brick_wall"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:smooth_glowstone_pressure_plate"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:smooth_dimstone_button"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:dullthorns_block"
+          "weight": 7,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 4.0,
+                "max": 22.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "gold_ingot"
         },
 
         {
           "type": "minecraft:item",
           "weight": 6,
-          "name": "minecraft:bowl"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 6,
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
-                "min": 1.0,
-                "max": 9.0,
+                "min": 4.0,
+                "max": 8.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "infernalexp:glowcoal"
+          "name": "infernalexp:glownuggets"
         },
+
         {
           "type": "minecraft:item",
-          "weight": 6,
+          "weight": 7,
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
-                "min": 1.0,
-                "max": 4.0,
+                "min": 4.0,
+                "max": 22.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "minecraft:porkchop"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "minecraft:crimson_fungus"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:luminous_fungus"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 2.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:luminous_fungus_cap"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 3.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:crimson_fungus_cap"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 2.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue"
+          "name": "minecraft:glowstone_dust"
         },
         {
           "type": "minecraft:item",
@@ -216,172 +105,15 @@
           "weight": 3,
           "functions": [
             {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.3,
-                "max": 0.6
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue_whip"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.5,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:diamond_hoe"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.6,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:diamond_sword"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.5,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:diamond_axe"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.4,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:diamond_shovel"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.3,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:diamond_pickaxe"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "minecraft:damaged_anvil"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:shroomlight_fungus"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:ascus_bomb"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "functions": [
-            {
               "function": "minecraft:set_count",
               "count": {
                 "min": 1.0,
-                "max": 5.0,
+                "max": 2.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "infernalexp:glownuggets"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:dullthorns"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "name": "infernalexp:music_disc_soul_spunk"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 3.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:moth_dust"
+          "name": "minecraft:gold_block"
         }
       ]
     }

--- a/src/main/resources/data/infernalexp/loot_tables/chests/glowstone_canyon_ruin_chest.json
+++ b/src/main/resources/data/infernalexp/loot_tables/chests/glowstone_canyon_ruin_chest.json
@@ -10,266 +10,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "weight": 9,
-          "name": "minecraft:bucket"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:dimstone"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:dullstone"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:glowstone_bricks"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:smooth_dimstone"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 7,
-          "name": "infernalexp:chiseled_dullstone_bricks"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "name": "infernalexp:glowdust_sand"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 10,
-          "name": "infernalexp:glowdust_stone"
-        },
-        {
-          "type": "minecraft:item",
           "weight": 3,
-          "name": "infernalexp:glowdust"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "name": "infernalexp:glowdust_stone_brick_slab"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "name": "infernalexp:smooth_glowstone_stairs"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "name": "infernalexp:dimstone_brick_slab"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "name": "infernalexp:dullstone_brick_wall"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:smooth_glowstone_pressure_plate"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:smooth_dimstone_button"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:dullthorns_block"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "name": "minecraft:bowl"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 9.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:glowcoal"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 6,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "minecraft:porkchop"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "minecraft:crimson_fungus"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 4.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:luminous_fungus"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 4,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 2.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:luminous_fungus_cap"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 3.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:crimson_fungus_cap"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 2.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "functions": [
-            {
-              "function": "minecraft:set_count",
-              "count": {
-                "min": 1.0,
-                "max": 1.0,
-                "type": "minecraft:uniform"
-              }
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue_stew"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 3,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.3,
-                "max": 0.6
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "infernalexp:blindsight_tongue_whip"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "functions": [
-            {
-              "function": "minecraft:set_damage",
-              "damage": {
-                "min": 0.3,
-                "max": 1.0
-              }
-            },
-            {
-              "function": "minecraft:enchant_randomly"
-            }
-          ],
-          "name": "minecraft:golden_sword"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "minecraft:damaged_anvil"
-        },
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:shroomlight_fungus"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
-          "name": "infernalexp:ascus_bomb"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 2,
           "functions": [
             {
               "function": "minecraft:set_count",
@@ -282,7 +23,21 @@
           ],
           "name": "infernalexp:glownuggets"
         },
-
+        {
+          "type": "minecraft:item",
+          "weight": 4,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 5.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "minecraft:glowstone_dust"
+        },
         {
           "type": "minecraft:item",
           "weight": 2,
@@ -291,36 +46,46 @@
               "function": "minecraft:set_count",
               "count": {
                 "min": 1.0,
-                "max": 4.0,
+                "max": 1.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "infernalexp:dullthorns"
+          "name": "infernalexp:glowsilk"
         },
-
         {
           "type": "minecraft:item",
-          "weight": 1,
-          "name": "infernalexp:music_disc_soul_spunk"
-        },
-
-        {
-          "type": "minecraft:item",
-          "weight": 1,
+          "weight": 5,
           "functions": [
             {
               "function": "minecraft:set_count",
               "count": {
                 "min": 1.0,
-                "max": 3.0,
+                "max": 9.0,
                 "type": "minecraft:uniform"
               }
             }
           ],
-          "name": "infernalexp:moth_dust"
+          "name": "infernalexp:gold_ingot"
+        },
+        {
+          "type": "minecraft:item",
+          "weight": 2,
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 1.0,
+                "type": "minecraft:uniform"
+              }
+            }
+          ],
+          "name": "infernalexp:music_disc_flush"
         }
       ]
     }
   ]
 }
+
+


### PR DESCRIPTION
The structure chests of all structures are incredibly cluttered with building blocks and random junk, however, this proposed change adds actual loot to them and makes them more organized.